### PR TITLE
Erro de não salvar endereço do pedido

### DIFF
--- a/functions/routes/ecom/modules/calculate-shipping.js
+++ b/functions/routes/ecom/modules/calculate-shipping.js
@@ -229,9 +229,7 @@ exports.post = ({ appSdk }, req, res) => {
               from: {
                 zip: originZip
               },
-              to: {
-                zip: data.data ? data.data.postalCode : params.to.zip
-              }
+              to: params.to
             },
             flags: ['mandae-ws']
           })

--- a/functions/routes/ecom/modules/calculate-shipping.js
+++ b/functions/routes/ecom/modules/calculate-shipping.js
@@ -229,7 +229,10 @@ exports.post = ({ appSdk }, req, res) => {
               from: {
                 zip: originZip
               },
-              to: params.to
+              to: {
+                ...params.to,
+                zip: (data.data && data.data.postalCode) || params.to.zip
+              }
             },
             flags: ['mandae-ws']
           })


### PR DESCRIPTION
Os pedidos estão sendo gerados apenas com cep de origem e cep de destino. De origem é ok, problema que de destino precisa ter as informações. Não fiz nenhum teste, mas como params.to.zip devem ter os outros